### PR TITLE
remove dependency for nri-jmx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.2 - 2019-03-19
+### Fixes
+- Remove unused dependency for nri-jmx]
+
 ## 1.0.1 - 2019-02-04
 ### Fixes
 - `EnableClusterAndNodes` and `EnableBuckets` actually worked now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.0.2 - 2019-03-19
 ### Fixes
-- Remove unused dependency for nri-jmx]
+- Remove unused dependency for nri-jmx
 
 ## 1.0.1 - 2019-02-04
 ### Fixes

--- a/Makefile-package.mk
+++ b/Makefile-package.mk
@@ -11,7 +11,7 @@ PACKAGER           = "New Relic Infrastructure Team <infrastructure-eng@newrelic
 PACKAGE_URL        = "https://www.newrelic.com/infrastructure"
 SUMMARY            = "New Relic Infrastructure $(INTEGRATION) Integration"
 DESCRIPTION        = "New Relic Infrastructure $(INTEGRATION) Integration extend the core New Relic\nInfrastructure agent's capabilities to allow you to collect metric and\nlive state data from $(INTEGRATION) components."
-FPM_COMMON_OPTIONS = --verbose -C $(SOURCE_DIR) -s dir -n $(PROJECT_NAME) -v $(VERSION) --iteration $(RELEASE) --prefix "" --license $(LICENSE) --vendor $(VENDOR) -m $(PACKAGER) --url $(PACKAGE_URL) --config-files /etc/newrelic-infra/ --description "$$(printf $(DESCRIPTION))" --depends "newrelic-infra >= 1.0.726" --depends "nrjmx"
+FPM_COMMON_OPTIONS = --verbose -C $(SOURCE_DIR) -s dir -n $(PROJECT_NAME) -v $(VERSION) --iteration $(RELEASE) --prefix "" --license $(LICENSE) --vendor $(VENDOR) -m $(PACKAGER) --url $(PACKAGE_URL) --config-files /etc/newrelic-infra/ --description "$$(printf $(DESCRIPTION))" --depends "newrelic-infra >= 1.0.726"
 FPM_DEB_OPTIONS    = -t deb -p $(PACKAGES_DIR)/deb/
 FPM_RPM_OPTIONS    = -t rpm -p $(PACKAGES_DIR)/rpm/ --epoch 0 --rpm-summary $(SUMMARY)
 

--- a/src/couchbase.go
+++ b/src/couchbase.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.couchbase"
-	integrationVersion = "1.0.1"
+	integrationVersion = "1.0.2"
 )
 
 var (


### PR DESCRIPTION
#### Description of the changes

nri-jmx is not used in the couchbase integration. This PR removes it as a dependency.
fixes #19

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
