### PR TITLE
fix: skip signtool invocation when NO_SIGN is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### Bugfix
+- Fixed Windows installer build failing with a SignTool error when `NO_SIGN` is set, by skipping the signing step instead of invoking `signtool` with no certificate imported
+
 ## v2.11.2 - 2026-07-22
 
 ### ⛓️ Dependencies

--- a/build/package/windows/nri-386-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-386-installer/nri-installer.wixproj
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>

--- a/build/package/windows/nri-amd64-installer/nri-installer.wixproj
+++ b/build/package/windows/nri-amd64-installer/nri-installer.wixproj
@@ -44,7 +44,7 @@
         </CreateProperty>
     </Target>
     <Target Name="SignInstaller">
-        <Exec Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
+        <Exec Condition="'$(noSign)' != 'true'" Command="&quot;$(SignToolPath)signtool.exe&quot; sign /s &quot;My&quot; /d &quot;$(pfx_certificate_description)&quot; /n &quot;$(pfx_certificate_description)&quot; &quot;$(OutputPath)$(OutputName).msi&quot;"/>
         <Copy SourceFiles="$(OutputPath)$(OutputName).msi" DestinationFiles="$(OutputPath)$(OutputName).x.y.z.msi"/>
         <!-- <Delete Files="$(OutputPath)$(OutputName).msi" /> -->
     </Target>


### PR DESCRIPTION
## Problem

Windows MSI packaging fails on test/PR builds with:

    SignTool error: No certificates were found that met all the given criteria.

## Root cause

`package_msi.ps1` skips importing the `.pfx` certificate when `NO_SIGN=true` (used for fake/test prerelease builds that don't have access to signing secrets), but `nri-installer.wixproj`'s `SignInstaller` target never checked `$(NoSign)` — it always invoked `signtool.exe`, which then failed because no cert had been imported.

## Fix

Add `Condition="'$(noSign)' != 'true'"` to the `Exec` task that invokes `signtool.exe`, in both the amd64 and 386 installer projects. This matches the existing pattern already used in `nri-mssql` and `nri-postgresql`.